### PR TITLE
Use \w+ in all feature extractors which detect words, and add tests

### DIFF
--- a/revscores/feature_extractors/badwords_added.py
+++ b/revscores/feature_extractors/badwords_added.py
@@ -4,7 +4,7 @@ from ..datasources import contiguous_segments_added
 from ..util.dependencies import depends
 from ..util.returns import returns
 
-WORD_RE = re.compile('[a-zA-Z]+', re.UNICODE)
+WORD_RE = re.compile('\w+', re.UNICODE)
 
 @depends(on=["language", contiguous_segments_added])
 @returns(int)

--- a/revscores/feature_extractors/prev_badwords.py
+++ b/revscores/feature_extractors/prev_badwords.py
@@ -4,7 +4,7 @@ from ..datasources import revision_text
 from ..util.dependencies import depends
 from ..util.returns import returns
 
-WORD_RE = re.compile('[a-zA-Z]+', re.UNICODE)
+WORD_RE = re.compile('\w+', re.UNICODE)
 
 @depends(on=["language", revision_text])
 @returns(int)

--- a/revscores/feature_extractors/prev_misspellings.py
+++ b/revscores/feature_extractors/prev_misspellings.py
@@ -4,7 +4,7 @@ from ..datasources import revision_text
 from ..util.dependencies import depends
 from ..util.returns import returns
 
-WORD_RE = re.compile('[a-zA-Z]+', re.UNICODE)
+WORD_RE = re.compile('\w+', re.UNICODE)
 
 @depends(on=["language", revision_text])
 @returns(int)

--- a/revscores/feature_extractors/prev_words.py
+++ b/revscores/feature_extractors/prev_words.py
@@ -4,7 +4,7 @@ from ..datasources import revision_text
 from ..util.dependencies import depends
 from ..util.returns import returns
 
-WORD_RE = re.compile('[a-zA-Z]+', re.UNICODE)
+WORD_RE = re.compile('\w+', re.UNICODE)
 
 @depends(on=[revision_text])
 @returns(int)

--- a/revscores/feature_extractors/tests/test_badwords_added.py
+++ b/revscores/feature_extractors/tests/test_badwords_added.py
@@ -9,8 +9,9 @@ def test_badwords_added():
     FakeLanguage = namedtuple("Language", ['badwords'])
     
     def badwords(words):
-        return (w for w in words if w in {"shit", "bitch"})
+        return (w for w in words if w in {"shit", "bitch", "palavrão"})
     
     language = FakeLanguage(badwords)
     
     eq_(badwords_added(language, ["This is shit words.", "And bitch."]), 2)
+    eq_(badwords_added(language, ["Um palavrão"]), 1)

--- a/revscores/feature_extractors/tests/test_prev_misspellings.py
+++ b/revscores/feature_extractors/tests/test_prev_misspellings.py
@@ -9,9 +9,11 @@ def test_prev_misspellings():
     FakeLanguage = namedtuple("Language", ['misspellings'])
     
     def misspellings(words):
-        return (w for w in words if w in {"werds"})
+        return (w for w in words if w in {"werds", "erros", "digtiação"})
     
     language = FakeLanguage(misspellings)
     revision_text = "This is werds. 7438 And stuff."
-    
     eq_(prev_misspellings(language, revision_text), 1)
+
+    revision_text = "Texto com erros de digtiação."
+    eq_(prev_misspellings(language, revision_text), 2)

--- a/revscores/feature_extractors/tests/test_prev_words.py
+++ b/revscores/feature_extractors/tests/test_prev_words.py
@@ -8,5 +8,7 @@ from ..prev_words import prev_words
 def test_prev_words():
     
     revision_text = "This is werds. 7438 And stuff."
-    
-    eq_(prev_words(revision_text), 5)
+    eq_(prev_words(revision_text), 6)
+
+    revision_text = "Luz, câmera, ação!"
+    eq_(prev_words(revision_text), 3)

--- a/revscores/feature_extractors/tests/test_words_removed.py
+++ b/revscores/feature_extractors/tests/test_words_removed.py
@@ -7,3 +7,4 @@ from ..words_removed import words_removed
 
 def test_words_removed():
     eq_(words_removed(["This is four words.", "And two."]), 6)
+    eq_(words_removed(["Aqui há seis palavras.", "Não sete!"]), 6)

--- a/revscores/feature_extractors/words_removed.py
+++ b/revscores/feature_extractors/words_removed.py
@@ -4,7 +4,7 @@ from ..datasources import contiguous_segments_removed
 from ..util.dependencies import depends
 from ..util.returns import returns
 
-WORD_RE = re.compile('[a-zA-Z]+', re.UNICODE)
+WORD_RE = re.compile('\w+', re.UNICODE)
 
 @depends(on=[contiguous_segments_removed])
 @returns(int)


### PR DESCRIPTION
Follow-up to 97a68a321fc79aa2874404f33870064def4871c4.

Also, update a test to reflect the fact that `\w` consider numbers as words.
