### PR TITLE
Add 'numpy', 'scykit-learn' and 'scipy' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-nltk
 deltas
-pytz
 mediawiki-utilities
+nltk
+numpy
+pytz
+scikit-learn
+scipy


### PR DESCRIPTION
These are necessary to run `python demonstrate_scorer.py`.

Before installing these packages, make sure you have these installed:
- python-sklearn
- python3.4-dev
- libatlas-base-dev
- gfortran
