### PR TITLE
Adds revision_oriented.revision.page.suggested.properties

### DIFF
--- a/revscoring/datasources/revision_oriented.py
+++ b/revscoring/datasources/revision_oriented.py
@@ -48,6 +48,7 @@ class Revision(DependentSet):
                  include_user_last_revision=False,
                  include_page=True,
                  include_page_creation=False,
+                 include_page_suggested=False,
                  include_content=False):
         super().__init__(name)
 
@@ -74,7 +75,8 @@ class Revision(DependentSet):
                 include_parent=False,
                 include_user_info=False,
                 include_page=False,
-                include_content=include_content
+                include_content=include_content,
+                include_page_suggested=False
             )
             """
             :class:`~revscoring.datasources.revision_oriented.Revision` : The
@@ -84,7 +86,8 @@ class Revision(DependentSet):
         if include_page:
             self.page = Page(
                 name + ".page",
-                include_creation=include_page_creation
+                include_creation=include_page_creation,
+                include_suggested=include_page_suggested
             )
             """
             :class:`~revscoring.datasources.revision_oriented.Page` : The
@@ -137,7 +140,8 @@ class User(DependentSet):
                 name + ".last_revision",
                 include_parent=False,
                 include_user=False,
-                include_content=False
+                include_content=False,
+                include_page_suggested=False
             )
             """
             :class:`~revscoring.datasources.revision_oriented.Revision` : The
@@ -169,7 +173,7 @@ class Page(DependentSet):
     Represents a revision's page
     """
 
-    def __init__(self, name, include_creation=False):
+    def __init__(self, name, include_creation=False, include_suggested=False):
         super().__init__(name)
         self.id = Datasource(name + ".id")
         "`int` : The page's ID"
@@ -187,12 +191,31 @@ class Page(DependentSet):
                 include_parent=False,
                 include_page=False,
                 include_content=False,
-                include_user_last_revision=False
+                include_user_last_revision=False,
+                include_page_suggested=False
             )
             """
             :class:`~revscoring.datasources.revision_oriented.Revision` : The
             first revision to the page.
             """
+
+        if include_suggested:
+            self.suggested = Suggested(name + ".suggestions")
+            """
+            :class:`~revscoring.datasources.revision_oriented.Suggested" :
+            The set of suggestions for a page.
+            """
+
+
+class Suggested(DependentSet):
+    """
+    Represents a set of intelligent suggestions about the structure of a page.
+    """
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.properties = Datasource(name + ".properties")
+        "`list` : The set of property suggestions for this page"
 
 
 class Namespace(DependentSet):
@@ -221,7 +244,8 @@ revision = Revision(
     "revision",
     include_page_creation=True,
     include_content=True,
-    include_user_last_revision=True
+    include_user_last_revision=True,
+    include_page_suggested=True
 )
 """
 Represents the base revision of interest.  Implements this structure:

--- a/revscoring/datasources/tests/test_revision_oriented.py
+++ b/revscoring/datasources/tests/test_revision_oriented.py
@@ -48,6 +48,8 @@ def test_revision():
     assert not hasattr(revision.page.creation, "page")
     assert not hasattr(revision.page.creation, "text")
     assert not hasattr(revision.page.creation, "diff")
+    assert hasattr(revision.page, "suggested")
+    check_datasource(revision.page.suggested.properties)
 
     # revision.page.creation.user
     check_datasource(revision.page.creation.user.id)

--- a/revscoring/errors.py
+++ b/revscoring/errors.py
@@ -70,6 +70,12 @@ class MissingResource(DependencyError):
     pass
 
 
+class QueryNotSupported(DependencyError):
+    def __init__(self, datasources, info=None, arg=None):
+        super().__init__("Query failed ({0}:{1})"
+                         .format(datasources, info))
+
+
 class RevisionNotFound(MissingResource):
     def __init__(self, datasources, rev_id=None, arg=None):
         super().__init__("Could not find revision ({0}:{1})"
@@ -86,6 +92,12 @@ class PageNotFound(MissingResource):
     def __init__(self, datasources, page_id=None, arg=None):
         super().__init__("Could not find page ({0}:{1})"
                          .format(datasources, repr(page_id)))
+
+
+class EntityNotFound(MissingResource):
+    def __init__(self, datasources, entity_id=None, arg=None):
+        super().__init__("Could not find entity ({0}:{1})"
+                         .format(datasources, repr(entity_id)))
 
 
 class UserDeleted(MissingResource):

--- a/revscoring/extractors/api/datasources.py
+++ b/revscoring/extractors/api/datasources.py
@@ -1,5 +1,6 @@
 from ...datasources import Datasource
-from ...errors import PageNotFound, RevisionNotFound, UserNotFound
+from ...errors import (EntityNotFound, PageNotFound, RevisionNotFound,
+                       UserNotFound)
 from .util import REV_PROPS, USER_PROPS
 
 
@@ -49,6 +50,26 @@ class PageCreationRevDoc(Datasource):
             raise PageNotFound(self.page, page_id)
         else:
             return rev_doc
+
+
+class PropertySuggestionDoc(Datasource):
+
+    def __init__(self, page, extractor):
+        self.page = page
+        self.extractor = extractor
+        super().__init__(page.suggested.properties.name + ".doc", self.process,
+                         depends_on=[page.title, extractor.dependents])
+
+    def process(self, entity_id, dependents):
+
+        property_suggestion_doc = \
+            self.extractor.get_property_suggestion_doc(entity_id)
+
+        # If we didn't find a revision for page creation, this is bad.  Error.
+        if property_suggestion_doc is None:
+            raise EntityNotFound(self.page, entity_id)
+        else:
+            return property_suggestion_doc
 
 
 class UserInfoDoc(Datasource):

--- a/revscoring/extractors/api/revision_oriented.py
+++ b/revscoring/extractors/api/revision_oriented.py
@@ -66,6 +66,22 @@ class RevisionPage(DependentSet):
             self.creation = Revision(page.creation, extractor,
                                      page_creation_doc)
 
+        if hasattr(page, 'suggested'):
+            self.suggested = PageSuggested(page, extractor)
+
+
+class PageSuggested(DependentSet):
+
+    def __init__(self, page, extractor):
+        super().__init__(page.suggested._name)
+
+        if hasattr(page.suggested, "properties"):
+            property_suggestion_doc = \
+                extractor.get_property_suggestion_search_doc(page)
+            self.properties = Datasource(
+                page.suggested.properties.name, identity,
+                depends_on=[property_suggestion_doc])
+
 
 class Namespace(DependentSet):
     def __init__(self, namespace, extractor, rev_doc, namespace_title):
@@ -132,3 +148,7 @@ def first(pair):
 
 def second(pair):
     return pair[1]
+
+
+def identity(val):
+    return val

--- a/revscoring/extractors/api/tests/test_datasources.py
+++ b/revscoring/extractors/api/tests/test_datasources.py
@@ -3,8 +3,8 @@ import pickle
 import mwapi
 
 from ....datasources import revision_oriented as ro
-from ..datasources import (RevDocById, PageCreationRevDoc, UserInfoDoc,
-                           LastUserRevDoc)
+from ..datasources import (LastUserRevDoc, PageCreationRevDoc,
+                           PropertySuggestionDoc, RevDocById, UserInfoDoc)
 from ..extractor import Extractor
 
 
@@ -23,6 +23,15 @@ def test_page_creation_rev_doc():
     hash(page_creation_rev_doc)
     assert (pickle.loads(pickle.dumps(page_creation_rev_doc)) ==
             page_creation_rev_doc)
+
+
+def test_property_suggestion_doc():
+    extractor = Extractor(mwapi.Session("foobar"))
+    property_suggestion_doc = PropertySuggestionDoc(ro.revision.page, extractor)
+
+    hash(property_suggestion_doc)
+    assert (pickle.loads(pickle.dumps(property_suggestion_doc)) ==
+            property_suggestion_doc)
 
 
 def test_user_info_doc():

--- a/revscoring/tests/test_errors.py
+++ b/revscoring/tests/test_errors.py
@@ -1,11 +1,11 @@
 import pickle
 import traceback
 
-
-from ..dependencies import DependentSet
+from ..dependencies import Dependent, DependentSet
 from ..errors import (CaughtDependencyError, CommentDeleted, DependencyError,
                       DependencyLoop, MissingResource, PageNotFound,
-                      RevisionNotFound, TextDeleted, UserDeleted, UserNotFound)
+                      QueryNotSupported, RevisionNotFound, TextDeleted,
+                      UserDeleted, UserNotFound)
 
 
 def test_exceptions_picklability():
@@ -25,6 +25,18 @@ def test_exceptions_picklability():
     assert str(dl) == "DependencyLoop: FooBar"
 
     mr = MissingResource("FooBar")
+    pickle.loads(pickle.dumps(mr))
+    assert str(mr) == "MissingResource: FooBar"
+
+    qns = QueryNotSupported(
+        Dependent("revision.page.suggested.properties"),
+        "Unrecognized value for parameter \"action\": wbsgetsuggestions.")
+    pickle.loads(pickle.dumps(qns))
+    assert str(qns) == (
+        "QueryNotSupported: Query failed " +
+        "(dependent.revision.page.suggested.properties:Unrecognized value for " +
+        "parameter \"action\": wbsgetsuggestions.)")
+
     pickle.loads(pickle.dumps(mr))
     assert str(mr) == "MissingResource: FooBar"
 


### PR DESCRIPTION
```
$ python
Python 3.5.1+ (default, Mar 30 2016, 22:46:26) 
[GCC 5.3.1 20160330] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mwapi
>>> from revscoring.extractors.api import Extractor
>>> extractor = Extractor(mwapi.Session("https://wikidata.org"))
>>> from revscoring.datasources import revision_oriented as ro
>>> extractor.extract(766416985, ro.revision.page.suggested.properties)
[{'rating': '0.5553102294603983', 'id': 'P31', 'url': '//www.wikidata.org/wiki/Property:P31', 'label': 'instance of', 'description': 'that class of which this subject is a particular example and member (subject typically an individual member with a proper name label); different from P279; using this property as a qualifier is deprecated—use P2868 or P3831 instead'}, {'rating': '0.5166941781838735', 'id': 'P21', 'url': ....}]
```