### PR TITLE
Fix revscoring extract for users with 2FA

### DIFF
--- a/revscoring/utilities/extract.py
+++ b/revscoring/utilities/extract.py
@@ -48,13 +48,14 @@ from tqdm import tqdm
 
 import docopt
 import mwapi
+import mwapi.cli
 import yamlconf
 from tabulate import tabulate
 
 from ..dependencies import Dependent
 from ..errors import CommentDeleted, RevisionNotFound, TextDeleted, UserDeleted
 from ..extractors import api
-from .util import dump_observation, get_user_pass, read_observations
+from .util import dump_observation, read_observations
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +79,7 @@ def main(argv=None):
     session = mwapi.Session(args['--host'],
                             user_agent="Revscoring extract utility")
     if args['--login']:
-        username, password = get_user_pass(args['--host'])
-        session.login(username, password)
+        mwapi.cli.do_login(session, args['--host'])
     extractor = api.Extractor(session)
 
     if args['--input'] == "<stdin>":

--- a/revscoring/utilities/util.py
+++ b/revscoring/utilities/util.py
@@ -1,12 +1,10 @@
 import base64
-import getpass
 import json
 import logging
 import os
 import pickle
 import random
 import signal
-import sys
 from collections import OrderedDict
 
 import yamlconf
@@ -19,13 +17,6 @@ DECODERS = {
     'str': lambda v: str(v),
     'bool': lambda v: v in ("True", "true", "1", "T", "y", "Y")
 }
-
-
-def get_user_pass(for_what):
-    sys.stderr.write("Log into " + for_what + "\n")
-    sys.stderr.write("Username: ")
-    sys.stderr.flush()
-    return open('/dev/tty').readline().strip(), getpass.getpass("Password: ")
 
 
 def read_observations(f):


### PR DESCRIPTION
By replacing (and removing) `get_user_pass` and using
mwapi's CLI features.