### PR TITLE
Revert "Allow API extractor to fetch deleted revisions"

### DIFF
--- a/revscoring/extractors/api/extractor.py
+++ b/revscoring/extractors/api/extractor.py
@@ -228,7 +228,7 @@ class Extractor(BaseExtractor):
 
         logger.debug("Building a map of {0} revisions: {1}"
                      .format(len(rev_ids), rev_ids))
-        rev_docs = self.query_revisions_by_revids(rev_ids, rvprop=rvprop, drvprop=rvprop)
+        rev_docs = self.query_revisions_by_revids(rev_ids, rvprop=rvprop)
 
         return {rd['revid']: rd for rd in rev_docs}
 
@@ -239,8 +239,8 @@ class Extractor(BaseExtractor):
             if len(batch_ids) == 0:
                 break
             else:
-                doc = self.session.get(action='query', prop='revisions|deletedrevisions',
-                                       revids=batch_ids, rvslots='main', drvslots='main',
+                doc = self.session.get(action='query', prop='revisions',
+                                       revids=batch_ids, rvslots='main',
                                        **params)
 
                 for page_doc in doc['query'].get('pages', {}).values():
@@ -342,9 +342,5 @@ def _normalize_revisions(page_doc):
                  if k != 'revisions'}
     if 'revisions' in page_doc:
         for revision_doc in page_doc['revisions']:
-            revision_doc['page'] = page_meta
-            yield revision_doc
-    if 'deletedrevisions' in page_doc:
-        for revision_doc in page_doc['deletedrevisions']:
             revision_doc['page'] = page_meta
             yield revision_doc


### PR DESCRIPTION
This breaks if the user (or even anon) is not allowed
to actually view deleted revisions (no matter whether
the revision in question actually is deleted).

This reverts commit b44c7c6ceedad1e7e62753d642360b61ac530f5b.