### PR TITLE
Removes python 3.4 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 group: stable
 language: python
 python:
-  # Track Python version on current production machines, Debian Jessie.
-  - 3.4
   # Track Python version on future production machines, Debian Stretch.
   - 3.5
 sudo: required


### PR DESCRIPTION
It was only erroring out and we don't need it anymore. 

https://phabricator.wikimedia.org/T215279