### PR TITLE
No dupes in trim() function

### DIFF
--- a/revscoring/features/functions.py
+++ b/revscoring/features/functions.py
@@ -37,8 +37,9 @@ def _trim(dependent, context, cache):
         elif isinstance(feature, Constant):
             pass
         else:
-            cache.add(feature)
-            yield feature
+            if feature not in cache:
+                cache.add(feature)
+                yield feature
 
 
 def vectorize_values(feature_values):

--- a/tests/features/test_functions.py
+++ b/tests/features/test_functions.py
@@ -16,6 +16,7 @@ def test_trim():
 
     assert list(trim(f1)) == [f1]
     assert list(trim([f1, f2, fv])) == [f1, f2, fv]
+    assert list(trim([f1, f2, f1 + f2, fv])) == [f1, f2, fv]
     assert (list(trim(log(max(f1 - f2, 1)))) ==
             [f1, f2])
 


### PR DESCRIPTION
Currently the trim() function doesn't make use of its cache to make sure it doesn't output duplicate features.  This updates the function to ensure we don't get duplicates and adds a test to demonstrate it. 