### PR TITLE
Release Automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ install:
   - pip install -r requirements.txt
   - python -m nltk.downloader stopwords
   - pip install -r test-requirements.txt
+  - pip install twine
 script:
   - flake8 . --max-line-length=85 --exclude=.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,doc
   - pytest --cov=revscoring -m "not nottravis"
@@ -69,3 +70,9 @@ notifications:
     on_failure: change
     template:
       - "%{repository_slug}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} %{build_url}"
+
+deploy:
+  provider: script
+  script: bash scripts/deploy.sh
+  on:
+    branch: master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,1 @@
+python setup.py sdist bdist_wheel && twine upload dist/* --skip-existing --username $PYPI_USER --password $PYPI_PASS


### PR DESCRIPTION
This PR adds the ability to deploy releases to PyPI via TravisCI.

This is done using a script (deploy.sh) which will build the binary and wheels, and upload via twine whenever the version gets incremented.

PyPI Credentials will be stored as private environment variables on the TravisCI repo.

Task: https://phabricator.wikimedia.org/T229850