### PR TITLE
Fixes zero vector for missing terms bug.

### DIFF
--- a/revscoring/datasources/meta/vectorizers.py
+++ b/revscoring/datasources/meta/vectorizers.py
@@ -11,7 +11,6 @@ from gensim.models.keyedvectors import KeyedVectors
 from ..datasource import Datasource
 
 ASSET_SEARCH_DIRS = ["word2vec/", "~/.word2vec/", "/var/share/word2vec/"]
-VECTOR_DIMENSIONS = 300
 
 
 class word2vec(Datasource):
@@ -40,20 +39,20 @@ class word2vec(Datasource):
             keyed_vectors[word]
             for word in words or [] if word in keyed_vectors]
         if len(list_of_vectors) == 0:
-            list_of_vectors = [[0] * VECTOR_DIMENSIONS]
+            list_of_vectors = [[0] * keyed_vectors.vector_size]
         return list_of_vectors
 
     @staticmethod
-    def load_kv(filename=None, path=None, limit=None):
+    def load_kv(filename=None, path=None, binary=False, limit=None):
         if path is not None:
             return KeyedVectors.load_word2vec_format(
-                path, binary=True, limit=limit)
+                path, binary=binary, limit=limit)
         elif filename is not None:
             for dir_path in ASSET_SEARCH_DIRS:
                 try:
                     path = os.path.join(dir_path, filename)
                     return KeyedVectors.load_word2vec_format(
-                        path, binary=True, limit=limit)
+                        path, binary=binary, limit=limit)
                 except FileNotFoundError:
                     continue
             raise FileNotFoundError("Please make sure that 'filename' \

--- a/revscoring/datasources/meta/vectorizers.py
+++ b/revscoring/datasources/meta/vectorizers.py
@@ -36,11 +36,12 @@ class word2vec(Datasource):
 
     @staticmethod
     def vectorize_words(keyed_vectors, words):
-        if not words:
-            return [[0] * VECTOR_DIMENSIONS]
-        return [keyed_vectors[word] if word in
-                keyed_vectors else [0] * VECTOR_DIMENSIONS
-                for word in words]
+        list_of_vectors = [
+            keyed_vectors[word]
+            for word in words or [] if word in keyed_vectors]
+        if len(list_of_vectors) == 0:
+            list_of_vectors = [[0] * VECTOR_DIMENSIONS]
+        return list_of_vectors
 
     @staticmethod
     def load_kv(filename=None, path=None, limit=None):

--- a/tests/datasources/meta/tests/test_vectorizers.py
+++ b/tests/datasources/meta/tests/test_vectorizers.py
@@ -7,9 +7,14 @@ from revscoring.datasources.meta import vectorizers
 from revscoring.dependencies import solve
 from revscoring.features import wikitext
 
-test_vectors = {'a': [1] * 300,
-                'b': [2] * 300,
-                'c': [3] * 300}
+
+class FakeVectors(dict):
+    pass
+test_vectors = FakeVectors({
+                'a': [1] * 100,
+                'b': [2] * 100,
+                'c': [3] * 100})
+test_vectors.vector_size = 100
 
 
 def vectorize_words(words):
@@ -21,10 +26,10 @@ def test_word2vec():
                               vectorize_words, name='word vectors')
     vector = solve(wv, cache={ro.revision.text: 'a bv c d'})
     assert len(vector) == 2
-    assert len(vector[0]) == 300
+    assert len(vector[0]) == 100
     vector = solve(wv, cache={ro.revision.text: ''})
     assert len(vector) == 1
-    assert len(vector[0]) == 300
+    assert len(vector[0]) == 100
 
     assert pickle.loads(pickle.dumps(wv)) == wv
 

--- a/tests/datasources/meta/tests/test_vectorizers.py
+++ b/tests/datasources/meta/tests/test_vectorizers.py
@@ -2,15 +2,14 @@ import pickle
 from unittest.mock import patch
 
 import pytest
-
 from revscoring.datasources import revision_oriented as ro
 from revscoring.datasources.meta import vectorizers
 from revscoring.dependencies import solve
 from revscoring.features import wikitext
 
 test_vectors = {'a': [1] * 300,
-                'b': [1] * 300,
-                'c': [1] * 300}
+                'b': [2] * 300,
+                'c': [3] * 300}
 
 
 def vectorize_words(words):
@@ -21,7 +20,7 @@ def test_word2vec():
     wv = vectorizers.word2vec(wikitext.revision.datasources.words,
                               vectorize_words, name='word vectors')
     vector = solve(wv, cache={ro.revision.text: 'a bv c d'})
-    assert len(vector) == 4
+    assert len(vector) == 2
     assert len(vector[0]) == 300
     vector = solve(wv, cache={ro.revision.text: ''})
     assert len(vector) == 1


### PR DESCRIPTION
We used to emit a zero vector when a term was missing.  Now we skip those terms so our averages aren't weird. 