### PR TITLE
Feature extraction images

### DIFF
--- a/revscoring/features/wikitext/datasources/parsed.py
+++ b/revscoring/features/wikitext/datasources/parsed.py
@@ -105,6 +105,14 @@ class Revision:
         Returns a list of html tag names present in the content of the revision
         """
 
+        self.tags_str = mappers.map(
+            str, self.tags,
+            name=self._name + ".tags_str"
+        )
+        """
+        Returns a list of tags present in the content of the revision as strings
+        """
+
         self.templates = get_key(
             mwparserfromhell.nodes.Template, self.node_class_map,
             default=[],
@@ -120,6 +128,14 @@ class Revision:
         )
         """
         Returns a list of template names present in the content of the revision
+        """
+
+        self.templates_str = mappers.map(
+            str, self.templates,
+            name=self._name + ".templates_str"
+        )
+        """
+        Returns a list of templates present in the content of the revision as strings
         """
 
     def heading_titles_matching(self, regex, name=None):
@@ -190,6 +206,20 @@ class Revision:
 
         return filters.regex_matching(regex, self.tag_names, name=name)
 
+    def tags_str_matching(self, regex, name=None):
+        """
+        Constructs a :class:`revscoring.Datasource` that returns all tags
+        that matches a regular expression as strings.
+        """
+        if not hasattr(regex, "pattern"):
+            regex = re.compile(regex, re.I)
+
+        if name is None:
+            name = "{0}({1})" \
+                   .format(self._name + ".tags_str_matching", regex.pattern)
+
+        return filters.regex_matching(regex, self.tags_str, name=name)
+
     def template_names_matching(self, regex, name=None):
         """
         Constructs a :class:`revscoring.Datasource` that returns all template
@@ -204,6 +234,21 @@ class Revision:
                            regex.pattern)
 
         return filters.regex_matching(regex, self.template_names, name=name)
+
+    def templates_str_matching(self, regex, name=None):
+        """
+        Constructs a :class:`revscoring.Datasource` that returns all templates
+        that matches a regular expression as strings.
+        """
+        if not hasattr(regex, "pattern"):
+            regex = re.compile(regex, re.I)
+
+        if name is None:
+            name = "{0}({1})" \
+                .format(self._name + ".templates_str_matching",
+                        regex.pattern)
+
+        return filters.regex_matching(regex, self.templates_str, name=name)
 
 
 def _process_wikicode(text):

--- a/tests/features/wikitext/tests/test_parsed.py
+++ b/tests/features/wikitext/tests/test_parsed.py
@@ -125,6 +125,29 @@ def test_tags():
             revision.ref_tags)
 
 
+def test_tags_str():
+
+    cache = {r_text: "This is [https://wikis.com].\n" +
+             "== Heading! ==\n" +
+             "<ref>Foo</ref> the <span>foobar</span>!\n" +
+             "=== Another heading! ==="}
+    assert (solve(revision.datasources.tags_str, cache=cache) ==
+            ["<ref>Foo</ref>", "<span>foobar</span>"])
+
+
+def test_tags_str_matching():
+    cache = {r_text: "This is [https://wikis.com].\n" +
+                     "== Heading! ==\n" +
+                     "<ref>{{Cite thing}}</ref> the {{citation needed}}\n" +
+                     "=== Another {{heading|foo}}! ==="}
+
+    ref = revision.datasources.tags_str_matching(
+        r"<ref>.*</ref>", name="enwiki.revision.ref_tags")
+
+    assert (solve(ref, cache=cache) ==
+            ["<ref>{{Cite thing}}</ref>"])
+
+
 def test_templates():
 
     cache = {r_text: "This is [https://wikis.com].\n" +
@@ -142,3 +165,27 @@ def test_templates():
             revision.templates)
     assert (pickle.loads(pickle.dumps(cite_templates)) ==
             cite_templates)
+
+
+def test_templates_str():
+
+    cache = {r_text: "This is [https://wikis.com].\n" +
+             "== Heading! ==\n" +
+             "<ref>{{Cite thing}}</ref> the {{citation needed}}\n" +
+             "=== Another {{heading|foo}}! ==="}
+    assert (solve(revision.datasources.templates_str, cache=cache) ==
+            ["{{Cite thing}}", "{{citation needed}}", "{{heading|foo}}"])
+
+
+def test_templates_str_matching():
+
+    cache = {r_text: "This is [https://wikis.com].\n" +
+             "== Heading! ==\n" +
+             "<ref>{{Cite thing}}</ref> the {{citation needed}}\n" +
+             "=== Another {{heading|foo}}! ==="}
+
+    cite_template = revision.datasources.templates_str_matching(
+        r"{{Cit.*}}", name="enwiki.revision.cite_template")
+
+    assert (solve(cite_template, cache=cache) ==
+            ["{{Cite thing}}", "{{citation needed}}"])


### PR DESCRIPTION
Add revscoring.features.wikitext.datasources.Revision.templates_with_name_matching method
Add revscoring.features.wikitext.datasources.Revision.tags_with_name_matching method

Images are only counted when they are in the format: [[File:Something.jpg]].
However, there are other ways of adding images into tags and templates. The tags and templates of concern need to be extracted, so that further parsing can be done.

Task: T180822