### PR TITLE
Added _extract_sections() method in features/wikitext/datsources/pars…

### DIFF
--- a/revscoring/features/wikitext/datasources/parsed.py
+++ b/revscoring/features/wikitext/datasources/parsed.py
@@ -137,6 +137,13 @@ class Revision:
         """
         Returns a list of templates present in the content of the revision as strings
         """
+        self.sections = execute_method(
+            "_extract_sections", self.wikicode,
+            name=self._name + ".content"
+        )
+        """
+        Returns list of sections in the article as wikicode shared node list
+        """
 
     def heading_titles_matching(self, regex, name=None):
         """
@@ -285,6 +292,9 @@ def _extract_tag_name(tag):
 
 def _extract_template_name(template):
     return str(template.name)
+
+def _extract_sections(template):
+    return mwparserfromhell.wikicode.Wikicode.get_sections(flat=True).template
 
 
 class HeadingOfLevel:

--- a/revscoring/features/wikitext/datasources/parsed.py
+++ b/revscoring/features/wikitext/datasources/parsed.py
@@ -137,9 +137,9 @@ class Revision:
         """
         Returns a list of templates present in the content of the revision as strings
         """
-        self.sections = execute_method(
-            "_extract_sections", self.wikicode,
-            name=self._name + ".content"
+        self.sections = Datasource(
+            self._name + ".section",
+            _extract_sections, depends_on=[self.wikicode]
         )
         """
         Returns list of sections in the article as wikicode shared node list
@@ -293,8 +293,8 @@ def _extract_tag_name(tag):
 def _extract_template_name(template):
     return str(template.name)
 
-def _extract_sections(template):
-    return mwparserfromhell.wikicode.Wikicode.get_sections(flat=True).template
+def _extract_sections(wikicode):
+    return wikicode.get_sections(flat=True)
 
 
 class HeadingOfLevel:

--- a/revscoring/features/wikitext/datasources/parsed.py
+++ b/revscoring/features/wikitext/datasources/parsed.py
@@ -293,6 +293,7 @@ def _extract_tag_name(tag):
 def _extract_template_name(template):
     return str(template.name)
 
+
 def _extract_sections(wikicode):
     return wikicode.get_sections(flat=True)
 


### PR DESCRIPTION
…ed.py and self.sections which returns sections

This enables dividing an article/revision into sections, which we require to judge text complexity as features in article quality. 

@halfak 