### PR TITLE
Make the 'returns' param of Feature required.

### DIFF
--- a/revscoring/features/feature.py
+++ b/revscoring/features/feature.py
@@ -35,6 +35,9 @@ class Feature(Dependent):
 
     def __init__(self, name, process=None, *, returns=None, depends_on=None):
         super().__init__(name, process, depends_on)
+        if returns is None:
+            raise TypeError(
+                "__init__() missing required named argument 'returns'")
         self.returns = returns
 
     def __call__(self, *args, **kwargs):

--- a/tests/features/test_feature.py
+++ b/tests/features/test_feature.py
@@ -40,7 +40,10 @@ def check_feature(feature, expected):
 
 
 def test_feature():
-    f = Feature("f")
+    with raises(TypeError):
+        f = Feature("f")
+
+    f = Feature("f", returns=int)
 
     assert pickle.loads(pickle.dumps(f)) == f
     assert solve(f, cache={f: 5}) == 5
@@ -50,7 +53,7 @@ def test_feature():
 
 
 def test_minimal_constructor():
-    myfive = Feature("five")
+    myfive = Feature("five", returns=int)
 
     assert myfive == five
 

--- a/tests/scoring/models/tests/test_model.py
+++ b/tests/scoring/models/tests/test_model.py
@@ -6,7 +6,7 @@ from revscoring.scoring.models.model import Classifier, Learned, Model
 
 
 def test_model():
-    m = Model([Feature("foo")], version="0.0.1")
+    m = Model([Feature("foo", returns=int)], version="0.0.1")
 
     assert m.info.lookup('version') == "0.0.1"
 
@@ -24,10 +24,10 @@ def test_from_config():
 
 
 def test_learned_model():
-    model = Learned([Feature("foo")])
+    model = Learned([Feature("foo", returns=int)])
     assert model.trained is None
 
 
 def test_classifier():
-    model = Classifier([Feature("foo")], [True, False])
+    model = Classifier([Feature("foo", returns=int)], [True, False])
     assert 'statustics' not in model.info

--- a/tests/scoring/models/tests/test_sklearn.py
+++ b/tests/scoring/models/tests/test_sklearn.py
@@ -70,7 +70,7 @@ class FakeIdentityProbabilityClassifierMultilabel(ProbabilityClassifier):
 
 def test_sklearn_classifier():
     skc = FakeIdentityClassifier(
-        [Feature("foo")], [True, False], version="0.0.1")
+        [Feature("foo", returns=int)], [True, False], version="0.0.1")
 
     assert skc.version == "0.0.1"
 
@@ -82,7 +82,7 @@ def test_sklearn_classifier():
 
 def test_sklearn_probabilityclassifier():
     skc = FakeIdentityProbabilityClassifier(
-        [Feature("foo")], [True, False], version="0.0.1")
+        [Feature("foo", returns=int)], [True, False], version="0.0.1")
 
     assert skc.version == "0.0.1"
 
@@ -96,7 +96,7 @@ def test_sklearn_probabilityclassifier():
 
 def test_sklearn_classifier_multilabel():
     skc = FakeIdentityClassifierMultilabel(
-        [Feature("foo")], ["A", "B"], multilabel=True,
+        [Feature("foo", returns=int)], ["A", "B"], multilabel=True,
         version="0.0.1", label_weights={"A": 5, "B": 0.5})
     expected_estimator_params = {'class_weight':
                                  [{0: 1, 1: 5}, {0: 1, 1: 0.5}]}
@@ -114,7 +114,7 @@ def test_sklearn_classifier_multilabel():
 
 def test_sklearn_probabilityclassifier_multilabel():
     skc = FakeIdentityProbabilityClassifierMultilabel(
-        [Feature("foo")], ["A", "B"], multilabel=True,
+        [Feature("foo", returns=int)], ["A", "B"], multilabel=True,
         version="0.0.1", label_weights={"A": 5, "B": 0.5})
     expected_estimator_params = {'class_weight':
                                  [{0: 1, 1: 5}, {0: 1, 1: 0.5}]}
@@ -130,12 +130,12 @@ def test_sklearn_probabilityclassifier_multilabel():
 
 def test_score():
     skc = FakeIdentityClassifier(
-        [Feature("foo")], [True, False], version="0.0.1")
+        [Feature("foo", returns=int)], [True, False], version="0.0.1")
     docs = skc.score_many([cv_feature_values[0][0]])
     assert len(docs) == 1
 
     skc = FakeIdentityProbabilityClassifier(
-        [Feature("foo")], [True, False], version="0.0.1")
+        [Feature("foo", returns=int)], [True, False], version="0.0.1")
     docs = skc.score_many([cv_feature_values[0][0]])
     assert len(docs) == 1
     assert 'probability' in docs[0]
@@ -143,13 +143,13 @@ def test_score():
 
 def test_score_many():
     skc = FakeIdentityClassifier(
-        [Feature("foo")], [True, False], version="0.0.1")
+        [Feature("foo", returns=int)], [True, False], version="0.0.1")
     features, labels = zip(*cv_feature_values)
     docs = skc.score_many(features)
     assert len(docs) == 10
 
     skc = FakeIdentityProbabilityClassifier(
-        [Feature("foo")], [True, False], version="0.0.1")
+        [Feature("foo", returns=int)], [True, False], version="0.0.1")
     features, labels = zip(*cv_feature_values)
     docs = skc.score_many(features)
     assert len(docs) == 10
@@ -159,5 +159,5 @@ def test_score_many():
 def test_sklearn_format_error():
     with raises(ValueError):
         skc = FakeIdentityClassifier(
-            [Feature("foo")], [True, False], version="0.0.1")
+            [Feature("foo", returns=int)], [True, False], version="0.0.1")
         skc.info.format(formatting="foo")


### PR DESCRIPTION
I ran into this while coaching someone else about building new features.  A Feature can never work in reality without knowing its own type.  So, it should fail when its type is not specified. 