### PR TITLE
Add words_to_watch for pt

### DIFF
--- a/revscoring/languages/portuguese.py
+++ b/revscoring/languages/portuguese.py
@@ -152,41 +152,41 @@ informal word detecting regexes.
 
 words_to_watch_regexes = [
     # Puffery
-	r'lendári[ao]s?', r'grandes?', r'eminentes?', r'visionári[ao]s?',
+    r'lendári[ao]s?', r'grandes?', r'eminentes?', r'visionári[ao]s?',
     r'notáve(?:l|is)', r'líder(?:es)?', r'célebres?', r'de última linha',
     r'extraordinári[ao]s?', r'brilhantes?', r'famos[ao]s?', r'renomad[ao]s?',
     r'prestigios[ao]s?', r'de nível mundial', r'respeitad[ao]s?',
     r'excepciona(?:l|is)', r'excelentes?', r'virtuos[ao]s?',
     r'de grande estima',
     # Contentious labels (-gate removed)
-	r'cult[ao]s?', r'racistas?', r'pervers[ao]s?', r'seitas?',
+    r'cult[ao]s?', r'racistas?', r'pervers[ao]s?', r'seitas?',
     r'fundamentalistas?', r'hereges?', r'extremistas?', r'negacionistas?',
     r'terroristas?', r'libertador(?:as?|es)?', r'neo[- ]?nazis(?:ta|mo)?',
     r'pseudo-?(ciência|científic[oa]s?|intelectua(?:l|is))',
     r'controvers[ao]s?',
     # Unsupported attributions
-	r'algu(?:n|ma)s dizem', r'acredita-se', r'muit[ao]s têm a opinião',
+    r'algu(?:n|ma)s dizem', r'acredita-se', r'muit[ao]s têm a opinião',
     r'a maioria sente', r'especialistas afirmam', r'frequentemente se relata',
-	r'é a opinião corrente', r'estudos mostram', r'a ciência diz',
+    r'é a opinião corrente', r'estudos mostram', r'a ciência diz',
     r'provou-se que',
-	# Expressions of doubt
-	r'supost[ao]s?', r'alegad[ao]s?', r'pretens[ao]s?', r'acusad[ao]s?',
+    # Expressions of doubt
+    r'supost[ao]s?', r'alegad[ao]s?', r'pretens[ao]s?', r'acusad[ao]s?',
     r'chamad[ao]s?',
-	# Editorializing
-	r'notavelmente', r'interessantemente', r'deve-se ter em mente',
-	r'claramente', r'certamente', r'sem dúvida', r'é claro', r'afortunadamente',
-	r'(?:in)?felizmente', r'tragicamente', r'precocemente',
-	# Synonyms for "said"
-	r'revel(?:ou|aram)', r'indic(?:ou|aram)', r'expôs', r'explic(?:ou|aram)',
+    # Editorializing
+    r'notavelmente', r'interessantemente', r'deve-se ter em mente',
+    r'claramente', r'certamente', r'sem dúvida', r'é claro', r'afortunadamente',
+    r'(?:in)?felizmente', r'tragicamente', r'precocemente',
+    # Synonyms for "said"
+    r'revel(?:ou|aram)', r'indic(?:ou|aram)', r'expôs', r'explic(?:ou|aram)',
     r'encontr(?:ou|aram)', r'not(?:ou|aram)', r'observ(?:ou|aram)',
     r'insist(?:iu|iram)', r'especul(?:ou|aram)', r'conjetur(?:ou|aram)',
     r'aleg(?:ou|aram)', r'afirm(?:ou|aram)', r'admit(?:iu|iram)',
     r'confess(?:ou|aram)', r'neg(?:ou|aram)',
-	# Lack of precision
-	r'falec(?:eu|eram)', r'fo(?:i|ram) desta para a melhor', r'deu sua vida',
+    # Lack of precision
+    r'falec(?:eu|eram)', r'fo(?:i|ram) desta para a melhor', r'deu sua vida',
     r'deram suas vidas', r'local de descanso', r'fazer amor', r'uma questão com',
     r'danos colaterais', r'limpeza étnica', r'convivendo com o câncer',
-	r'sem visão', r'pessoas com cegueira',
+    r'sem visão', r'pessoas com cegueira',
 ]
 
 words_to_watch = RegexMatches(name + ".words_to_watch", words_to_watch_regexes)

--- a/revscoring/languages/portuguese.py
+++ b/revscoring/languages/portuguese.py
@@ -149,3 +149,48 @@ informals = RegexMatches(name + ".informals", informal_regexes)
 :class:`~revscoring.languages.features.RegexMatches` features via a list of
 informal word detecting regexes.
 """
+
+words_to_watch_regexes = [
+    # Puffery
+	r'lendári[ao]s?', r'grandes?', r'eminentes?', r'visionári[ao]s?',
+    r'notáve(?:l|is)', r'líder(?:es)?', r'célebres?', r'de última linha',
+    r'extraordinári[ao]s?', r'brilhantes?', r'famos[ao]s?', r'renomad[ao]s?',
+    r'prestigios[ao]s?', r'de nível mundial', r'respeitad[ao]s?',
+    r'excepciona(?:l|is)', r'excelentes?', r'virtuos[ao]s?',
+    r'de grande estima',
+    # Contentious labels (-gate removed)
+	r'cult[ao]s?', r'racistas?', r'pervers[ao]s?', r'seitas?',
+    r'fundamentalistas?', r'hereges?', r'extremistas?', r'negacionistas?',
+    r'terroristas?', r'libertador(?:as?|es)?', r'neo[- ]?nazis(?:ta|mo)?',
+    r'pseudo-?(ciência|científic[oa]s?|intelectua(?:l|is))',
+    r'controvers[ao]s?',
+    # Unsupported attributions
+	r'algu(?:n|ma)s dizem', r'acredita-se', r'muit[ao]s têm a opinião',
+    r'a maioria sente', r'especialistas afirmam', r'frequentemente se relata',
+	r'é a opinião corrente', r'estudos mostram', r'a ciência diz',
+    r'provou-se que',
+	# Expressions of doubt
+	r'supost[ao]s?', r'alegad[ao]s?', r'pretens[ao]s?', r'acusad[ao]s?',
+    r'chamad[ao]s?',
+	# Editorializing
+	r'notavelmente', r'interessantemente', r'deve-se ter em mente',
+	r'claramente', r'certamente', r'sem dúvida', r'é claro', r'afortunadamente',
+	r'(?:in)?felizmente', r'tragicamente', r'precocemente',
+	# Synonyms for "said"
+	r'revel(?:ou|aram)', r'indic(?:ou|aram)', r'expôs', r'explic(?:ou|aram)',
+    r'encontr(?:ou|aram)', r'not(?:ou|aram)', r'observ(?:ou|aram)',
+    r'insist(?:iu|iram)', r'especul(?:ou|aram)', r'conjetur(?:ou|aram)',
+    r'aleg(?:ou|aram)', r'afirm(?:ou|aram)', r'admit(?:iu|iram)',
+    r'confess(?:ou|aram)', r'neg(?:ou|aram)',
+	# Lack of precision
+	r'falec(?:eu|eram)', r'fo(?:i|ram) desta para a melhor', r'deu sua vida',
+    r'deram suas vidas', r'local de descanso', r'fazer amor', r'uma questão com',
+    r'danos colaterais', r'limpeza étnica', r'convivendo com o câncer',
+	r'sem visão', r'pessoas com cegueira',
+]
+
+words_to_watch = RegexMatches(name + ".words_to_watch", words_to_watch_regexes)
+"""
+:class:`~revscoring.languages.features.RegexMatches` features via a list of
+problematic words and phrases for use in reference text
+"""

--- a/tests/languages/test_portuguese.py
+++ b/tests/languages/test_portuguese.py
@@ -135,6 +135,14 @@ def test_informals():
         pickle.dumps(portuguese.informals))
 
 
+def test_words_to_watch():
+    compare_extraction(portuguese.words_to_watch.revision.datasources.matches,
+                       WORDS_TO_WATCH, OTHER)
+
+    assert portuguese.words_to_watch == \
+        pickle.loads(pickle.dumps(portuguese.words_to_watch))
+
+
 def test_dictionary():
     cache = {r_text: "A haver, rebeliões: e m80 da Normandia."}
     assert (solve(portuguese.dictionary.revision.datasources.dict_words,

--- a/tests/languages/test_portuguese.py
+++ b/tests/languages/test_portuguese.py
@@ -106,7 +106,7 @@ INFORMAL = [
 
 WORDS_TO_WATCH = [
     # Puffery
-	"lendária", "lendárias", "lendário", "lendários", "grande", "grandes",
+    "lendária", "lendárias", "lendário", "lendários", "grande", "grandes",
     "eminente", "eminentes", "visionária", "visionárias", "visionário",
     "visionários", "notável", "notáveis", "líder", "líderes", "célebre",
     "célebres", "de última linha", "extraordinária", "extraordinárias",
@@ -117,7 +117,7 @@ WORDS_TO_WATCH = [
     "respeitados", "excepcional", "excepcionais", "excelente", "excelentes",
     "virtuosa", "virtuosas", "virtuoso", "virtuosos", "de grande estima",
     # Contentious labels (-gate removed)
-	"culta", "cultas", "culto", "cultos", "racista", "racistas", "perversa",
+    "culta", "cultas", "culto", "cultos", "racista", "racistas", "perversa",
     "perversas", "perverso", "perversos", "seita", "seitas",
     "fundamentalista", "fundamentalistas", "herege", "hereges", "extremista",
     "extremistas", "negacionista", "negacionistas", "terrorista",
@@ -131,27 +131,27 @@ WORDS_TO_WATCH = [
     "pseudo-científicas", "controversa", "controversas", "controverso",
     "controversos",
     # Unsupported attributions
-	"alguns dizem", "algumas dizem", "acredita-se", "muitos têm a opinião",
+    "alguns dizem", "algumas dizem", "acredita-se", "muitos têm a opinião",
     "muitas têm a opinião", "a maioria sente", "especialistas afirmam",
     "frequentemente se relata", "é a opinião corrente", "estudos mostram",
     "a ciência diz", "provou-se que",
-	# Expressions of doubt
-	"suposta", "supostas", "suposto", "supostos", "alegada", "alegadas",
+    # Expressions of doubt
+    "suposta", "supostas", "suposto", "supostos", "alegada", "alegadas",
     "alegado", "alegados", "pretensa", "pretensas", "pretenso", "pretensos",
     "acusada", "acusadas", "acusado", "acusados", "chamada", "chamadas",
     "chamado", "chamados",
-	# Editorializing
-	"notavelmente", "interessantemente", "deve-se ter em mente",
-	"claramente", "certamente", "sem dúvida", "é claro", "afortunadamente",
-	"felizmente", "infelizmente", "tragicamente", "precocemente",
-	# Synonyms for "said"
-	"revelou", "revelaram", "indicou", "indicaram", "expôs", "explicou", "explicaram",
+    # Editorializing
+    "notavelmente", "interessantemente", "deve-se ter em mente",
+    "claramente", "certamente", "sem dúvida", "é claro", "afortunadamente",
+    "felizmente", "infelizmente", "tragicamente", "precocemente",
+    # Synonyms for "said"
+    "revelou", "revelaram", "indicou", "indicaram", "expôs", "explicou", "explicaram",
     "encontrou", "encontraram", "notou", "notaram", "observou", "observaram",
     "insistiu", "insistiram", "especulou", "especularam", "conjeturou", "conjeturaram",
     "alegou", "alegaram", "afirmou", "afirmaram", "admitiu", "admitiram",
     "confessou", "confessaram", "negou", "negaram",
-	# Lack of precision
-	"faleceu", "faleceram", "foi desta para a melhor",
+    # Lack of precision
+    "faleceu", "faleceram", "foi desta para a melhor",
     "foram desta para a melhor", "deu sua vida", "deram suas vidas",
     "local de descanso", "fazer amor", "uma questão com", "danos colaterais",
     "limpeza étnica", "convivendo com o câncer", "sem visão",

--- a/tests/languages/test_portuguese.py
+++ b/tests/languages/test_portuguese.py
@@ -104,6 +104,60 @@ INFORMAL = [
     "xau"
 ]
 
+WORDS_TO_WATCH = [
+    # Puffery
+	"lendária", "lendárias", "lendário", "lendários", "grande", "grandes",
+    "eminente", "eminentes", "visionária", "visionárias", "visionário",
+    "visionários", "notável", "notáveis", "líder", "líderes", "célebre",
+    "célebres", "de última linha", "extraordinária", "extraordinárias",
+    "extraordinário", "extraordinários", "brilhantes", "brilhantes", "famosa",
+    "famosas", "famoso", "famosos", "renomada", "renomadas", "renomado",
+    "renomados", "prestigiosa", "prestigiosas", "prestigioso", "prestigiosos",
+    "de nível mundial", "respeitada", "respeitadas", "respeitado",
+    "respeitados", "excepcional", "excepcionais", "excelente", "excelentes",
+    "virtuosa", "virtuosas", "virtuoso", "virtuosos", "de grande estima",
+    # Contentious labels (-gate removed)
+	"culta", "cultas", "culto", "cultos", "racista", "racistas", "perversa",
+    "perversas", "perverso", "perversos", "seita", "seitas",
+    "fundamentalista", "fundamentalistas", "herege", "hereges", "extremista",
+    "extremistas", "negacionista", "negacionistas", "terrorista",
+    "terroristas", "libertador", "libertadora", "libertadoras", "libertadores",
+    "neonazis", "neo-nazis", "neo nazis", "neonazista", "neo-nazista",
+    "neo nazista", "neonazismo", "neo-nazismo", "neo nazismo", "pseudociência",
+    "pseudo-ciência", "pseudointelectual", "pseudo-intelectual",
+    "pseudointelectuais", "pseudo-intelectuais", "pseudocientífico",
+    "pseudocientífica", "pseudocientíficos", "pseudocientíficas",
+    "pseudo-científico", "pseudo-científica", "pseudo-científicos",
+    "pseudo-científicas", "controversa", "controversas", "controverso",
+    "controversos",
+    # Unsupported attributions
+	"alguns dizem", "algumas dizem", "acredita-se", "muitos têm a opinião",
+    "muitas têm a opinião", "a maioria sente", "especialistas afirmam",
+    "frequentemente se relata", "é a opinião corrente", "estudos mostram",
+    "a ciência diz", "provou-se que",
+	# Expressions of doubt
+	"suposta", "supostas", "suposto", "supostos", "alegada", "alegadas",
+    "alegado", "alegados", "pretensa", "pretensas", "pretenso", "pretensos",
+    "acusada", "acusadas", "acusado", "acusados", "chamada", "chamadas",
+    "chamado", "chamados",
+	# Editorializing
+	"notavelmente", "interessantemente", "deve-se ter em mente",
+	"claramente", "certamente", "sem dúvida", "é claro", "afortunadamente",
+	"felizmente", "infelizmente", "tragicamente", "precocemente",
+	# Synonyms for "said"
+	"revelou", "revelaram", "indicou", "indicaram", "expôs", "explicou", "explicaram",
+    "encontrou", "encontraram", "notou", "notaram", "observou", "observaram",
+    "insistiu", "insistiram", "especulou", "especularam", "conjeturou", "conjeturaram",
+    "alegou", "alegaram", "afirmou", "afirmaram", "admitiu", "admitiram",
+    "confessou", "confessaram", "negou", "negaram",
+	# Lack of precision
+	"faleceu", "faleceram", "foi desta para a melhor",
+    "foram desta para a melhor", "deu sua vida", "deram suas vidas",
+    "local de descanso", "fazer amor", "uma questão com", "danos colaterais",
+    "limpeza étnica", "convivendo com o câncer", "sem visão",
+    "pessoas com cegueira",
+]
+
 OTHER = [
     """
     A batalha de Hastings foi travada em 14 de outubro de 1066 entre o exército


### PR DESCRIPTION
Adapted from [w:pt:Wikipédia:Palavras a evitar](https://pt.wikipedia.org/wiki/Wikipedia:Palavras_a_evitar?oldid=55314927).