### PR TITLE
Attempt to cast values to the desired return types

### DIFF
--- a/revscoring/features/feature.py
+++ b/revscoring/features/feature.py
@@ -100,8 +100,11 @@ class Feature(Dependent):
         if isinstance(value, self.returns):
             return value
         else:
-            raise ValueError("Expected {0}, but got {1} instead."
-                             .format(self.returns, type(value)))
+            try:
+                return self.returns(value)
+            except ValueError:
+                raise ValueError("Expected {0}, but got {1} instead."
+                                    .format(self.returns, type(value)))
 
     @classmethod
     def or_constant(self, val):


### PR DESCRIPTION
With this patch, attempting to inject an `int` as the value of a feature which is supposed to return a `float` should not cause erros like this:
https://ores.wikimedia.org/v3/scores/ptwiki/57185234/articlequality?features&feature.ptwiki.revision.paragraphs_without_refs_total_length=500
```json
{
  "ptwiki": {
    "models": {
      "articlequality": {
        "version": "0.8.0"
      }
    },
    "scores": {
      "57185234": {
        "articlequality": {
          "error": {
            "message": "ValueError: Failed to process feature.(ptwiki.revision.paragraphs_without_refs_total_length + 1): Expected <class 'float'>, but got <class 'int'> instead.\nTraceback (most recent call last):\n  File \"/srv/deployment/ores/deploy-cache/revs/514f94ae027c462c47f1bffbab87568a3a30acb7/venv/lib/python3.5/site-packages/revscoring/dependencies/functions.py\", line 244, in _solve\n    value = dependent(*args)\n  File \"/srv/deployment/ores/deploy-cache/revs/514f94ae027c462c47f1bffbab87568a3a30acb7/venv/lib/python3.5/site-packages/revscoring/features/feature.py\", line 44, in __call__\n    return self.validate(value)\n  File \"/srv/deployment/ores/deploy-cache/revs/514f94ae027c462c47f1bffbab87568a3a30acb7/venv/lib/python3.5/site-packages/revscoring/features/feature.py\", line 101, in validate\n    .format(self.returns, type(value)))\nValueError: Expected <class 'float'>, but got <class 'int'> instead.\n",
            "type": "CaughtDependencyError"
          }
        }
      }
    }
  }
}
```
Users should be able to enter either `500` or `500.0` as the value.