### PR TITLE
Replace references to APIExtractor in docs

### DIFF
--- a/docs/notes_on_adhoc_jobs.txt
+++ b/docs/notes_on_adhoc_jobs.txt
@@ -9,22 +9,18 @@ makes predictions
 Imagine some python (requires `pip install mwreverts`):
 
 # There exists a model file at enwiki.model
-from itertools import groupby
-
 from mwapi import Session
 import mwreverts
 
 from revscoring.extractors.api.extractor import Extractor
 from revscoring.scoring.models import LinearSVC
 
-model = LinearSVC.MODEL.from_file(open("enwiki.model", 'rb'))
-
 session = Session("https://en.wikipedia.org/w/api.php")
 extractor = Extractor(session)
 
-scorer = LinearSVC(extractor, model)
+model = Model.load(open("enwiki.model", "rb"))
 
-api_result = session.get(action='query', titles = 'Main Page', prop='revisions', rvlimit=500, rvprop='sha1')
+api_result = session.get(action='query', titles='Main Page', prop='revisions', rvlimit=500, rvprop='sha1|ids')
 revisions = next(iter(api_result['query']['pages'].values()))['revisions']
 
 # Content that has been revision-deleted has a hidden SHA-1
@@ -36,8 +32,8 @@ for revert in mwreverts.detect((revision['sha1'], revision) for revision in revi
         reverted_set.add(reverted['sha1'])
 
 for revision in revisions:
-    if revision['sha1'] not in reverted_set: # no revert happened
-        score = scorer.score(revision['revid'])
+    if revision['sha1'] not in reverted_set:  # no revert happened
+        score = model.score([revision['revid']])['probability'][True]
 
         if score > .5:
-            print(rev['pagetitle'])
+            print(revision['pagetitle'])

--- a/docs/notes_on_adhoc_jobs.txt
+++ b/docs/notes_on_adhoc_jobs.txt
@@ -11,15 +11,15 @@ Imagine some python:
 # There exists a model file at ptwiki.model
 from itertools import groupby
 
-from mw import api
+from mwapi import Session
 from mw.lib import reverts
 
 from revscoring.extractors.api.extractor import Extractor
-from revscoring.scorers import LinearSVC
+from revscoring.scoring.models import LinearSVC
 
 model = LinearSVC.MODEL.from_file(open("ptwiki.model", 'rb'))
 
-session = api.Session("https://pt.wikipedia.org/w/api.php")
+session = Session("https://pt.wikipedia.org/w/api.php")
 extractor = Extractor(session)
 
 scorer = LinearSVC(extractor, model)

--- a/docs/notes_on_adhoc_jobs.txt
+++ b/docs/notes_on_adhoc_jobs.txt
@@ -14,13 +14,13 @@ from itertools import groupby
 from mw import api
 from mw.lib import reverts
 
-from revscores import APIExtractor
-from revscores.scorers import LinearSVC
+from revscoring.extractors.api.extractor import Extractor
+from revscoring.scorers import LinearSVC
 
 model = LinearSVC.MODEL.from_file(open("ptwiki.model", 'rb'))
 
 session = api.Session("https://pt.wikipedia.org/w/api.php")
-extractor = APIExtractor(session)
+extractor = Extractor(session)
 
 scorer = LinearSVC(extractor, model)
 

--- a/docs/notes_on_adhoc_jobs.txt
+++ b/docs/notes_on_adhoc_jobs.txt
@@ -1,46 +1,43 @@
 Given a set of rev_ids.  Return the vandal scores.
 
-$ cat rev_ids.tsv | predict --source=ptwiki_api.yaml --scorer=ptwiki_svc.yaml > predictions.tsv
+$ cat rev_ids.tsv | predict --source=enwiki_api.yaml --scorer=enwiki_svc.yaml > predictions.tsv
 
 ^^ This imagines a UNIX command line utility that takes a set of rev_ids and
 makes predictions
 
 
-Imagine some python:
+Imagine some python (requires `pip install mwreverts`):
 
-# There exists a model file at ptwiki.model
+# There exists a model file at enwiki.model
 from itertools import groupby
 
 from mwapi import Session
-from mw.lib import reverts
+import mwreverts
 
 from revscoring.extractors.api.extractor import Extractor
 from revscoring.scoring.models import LinearSVC
 
-model = LinearSVC.MODEL.from_file(open("ptwiki.model", 'rb'))
+model = LinearSVC.MODEL.from_file(open("enwiki.model", 'rb'))
 
-session = Session("https://pt.wikipedia.org/w/api.php")
+session = Session("https://en.wikipedia.org/w/api.php")
 extractor = Extractor(session)
 
 scorer = LinearSVC(extractor, model)
 
-revisions = session.revisions.query(after=<one week ago>,
-                                    before=<now>)
+api_result = session.get(action='query', titles = 'Main Page', prop='revisions', rvlimit=500, rvprop='sha1')
+revisions = next(iter(api_result['query']['pages'].values()))['revisions']
 
+# Content that has been revision-deleted has a hidden SHA-1
+revisions = [revision for revision in revisions if 'sha1hidden' not in revision]
+reverted_set = set()
 
-page_revisions = groupby(revisions, r['pageid'])
+for revert in mwreverts.detect((revision['sha1'], revision) for revision in revisions):
+    for reverted in revert.reverteds:
+        reverted_set.add(reverted['sha1'])
 
-for page_id, revisions in page_revisions:
-    
-    detector = reverts.Detector()
-    
-    for rev in revisions:
-        
-        revert = detector.process(rev['sha1'], rev)
-        
-        if revert is None: # no revert happened
-            
-            score = scorer.score(rev['revid'])
-            
-            if score > .5:
-                print(rev['pagetitle'])
+for revision in revisions:
+    if revision['sha1'] not in reverted_set: # no revert happened
+        score = scorer.score(revision['revid'])
+
+        if score > .5:
+            print(rev['pagetitle'])

--- a/revscoring/extractors/extractor.py
+++ b/revscoring/extractors/extractor.py
@@ -43,7 +43,7 @@ class OfflineExtractor(Extractor):
     def __init__(self):
         super().__init__()
         logger.warning("Loading OfflineExtractor.  You probably want an " +
-                       "extractors.api.extractor.Extractor unless this is the test server.")
+                       "revscoring.extractors.api.extractor.Extractor unless this is the test server.")
 
     def extract(self, rev_ids, dependents, context=None, caches=None,
                 cache=None, profile=None):

--- a/revscoring/extractors/extractor.py
+++ b/revscoring/extractors/extractor.py
@@ -43,7 +43,7 @@ class OfflineExtractor(Extractor):
     def __init__(self):
         super().__init__()
         logger.warning("Loading OfflineExtractor.  You probably want an " +
-                       "APIExtractor unless this is the test server.")
+                       "extractors.api.extractor.Extractor unless this is the test server.")
 
     def extract(self, rev_ids, dependents, context=None, caches=None,
                 cache=None, profile=None):


### PR DESCRIPTION
The code was previously refactored but a few references in docs were not
updated.
It looks like the "notes on adhoc job" is old and could still be out of
data