### PR TITLE
Improve error message when decoding a non-item revision from Wikidata

### DIFF
--- a/revscoring/about.py
+++ b/revscoring/about.py
@@ -1,5 +1,5 @@
 __name__ = "revscoring"
-__version__ = "2.11.1"
+__version__ = "2.11.2"
 __author__ = "Aaron Halfaker"
 __author_email__ = "ahalfaker@wikimedia.org"
 __description__ = ("A set of utilities for generating quality scores for " +

--- a/revscoring/errors.py
+++ b/revscoring/errors.py
@@ -76,6 +76,18 @@ class QueryNotSupported(DependencyError):
                          .format(datasources, info))
 
 
+class UnexpectedContentType(DependencyError):
+    def __init__(self, text, content_type, arg=None):
+        self.text = text
+        self.content_type = content_type
+        super().__init__("Expected content of type {0}, "
+                         "but the following can't be parsed "
+                         "(max 50 chars showed): {1}"
+                         .format(content_type, text[:50]))
+    def __reduce__(self):
+        return (UnexpectedContentType, (self.text, self.content_type))
+
+
 class RevisionNotFound(MissingResource):
     def __init__(self, datasources, rev_id=None, arg=None):
         super().__init__("Could not find revision ({0}:{1})"

--- a/revscoring/features/wikibase/datasources/revision_oriented.py
+++ b/revscoring/features/wikibase/datasources/revision_oriented.py
@@ -4,6 +4,7 @@ import mwbase
 
 from revscoring.datasources import Datasource
 from revscoring.dependencies import DependentSet
+from revscoring.errors import UnexpectedContentType
 
 from .diff import Diff
 
@@ -114,7 +115,10 @@ class Revision(DependentSet):
 
 def _process_entity_doc(text):
     if text is not None:
-        return json.loads(text)
+        try:
+            return json.loads(text)
+        except json.decoder.JSONDecodeError:
+            raise UnexpectedContentType(text, "JSON")
     else:
         return None
 

--- a/tests/features/wikibase/tests/test_revision.py
+++ b/tests/features/wikibase/tests/test_revision.py
@@ -1,9 +1,11 @@
 import os
 import pickle
+import pytest
 
 from revscoring.datasources import revision_oriented
 from revscoring.dependencies import solve
 from revscoring.features.wikibase.revision_oriented import revision
+from revscoring.errors import UnexpectedContentType
 
 pwd = os.path.dirname(os.path.realpath(__file__))
 ALAN_TEXT = open(os.path.join(pwd, "alan_turing.json")).read()
@@ -25,6 +27,9 @@ def test_entity_doc():
     assert (pickle.loads(pickle.dumps(revision.datasources.entity_doc)) ==
             revision.datasources.entity_doc)
 
+    with pytest.raises(UnexpectedContentType):
+        solve(revision.datasources.entity_doc, cache={r_text:
+                "unexpected content type"})
 
 def test_entity():
     entity = solve(revision.datasources.entity, cache={r_text: None})

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -6,7 +6,8 @@ from revscoring.errors import (CaughtDependencyError, CommentDeleted,
                                DependencyError, DependencyLoop,
                                MissingResource, PageNotFound,
                                QueryNotSupported, RevisionNotFound,
-                               TextDeleted, UserDeleted, UserNotFound)
+                               TextDeleted, UserDeleted, UserNotFound,
+                               UnexpectedContentType)
 
 
 def test_exceptions_picklability():
@@ -69,3 +70,10 @@ def test_exceptions_picklability():
     cde = CaughtDependencyError("Test", RuntimeError("Foo"))
     pickle.loads(pickle.dumps(cde))
     assert str(cde) == "RuntimeError: Test\nNone"
+
+    uct = UnexpectedContentType("Test", "JSON")
+    pickle.loads(pickle.dumps(uct))
+    assert str(uct) == ("UnexpectedContentType: "
+                        "Expected content of type JSON, "
+                        "but the following can't be parsed "
+                        "(max 50 chars showed): Test")


### PR DESCRIPTION
Revscoring returns a very verbose and cryptic JSONDecodeError stacktrace
when it tries to score a non-item Wikidata revision with the item
quality model (for example, a User/Talk page change, etc..).
This change adds a new exception meant to capture this kind of error,
to wrap it in a clearer error message.

Co-authored-by: halfak <aaron.halfaker@gmail.com>,
Luca Toscano <ltoscano@wikimedia.org>
Bug: T302851