### PR TITLE
Release revscoring 2.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.11.3]
+
+* No-op release, the artifact uploaded for 2.11.2 may not be the correct
+  one, hence a new release to avoid issues (first time publishing
+  a revscoring artifact for a new uploader).
+
 ## [2.11.2]
 
 ### Fixed

--- a/revscoring/about.py
+++ b/revscoring/about.py
@@ -1,5 +1,5 @@
 __name__ = "revscoring"
-__version__ = "2.11.2"
+__version__ = "2.11.3"
 __author__ = "Aaron Halfaker"
 __author_email__ = "ahalfaker@wikimedia.org"
 __description__ = ("A set of utilities for generating quality scores for " +


### PR DESCRIPTION
The release 2.11.2 should be the right one, but I realized right now
that I published the artifact from my local repo that may have been
messed up (limited to the new code that Aiko wrote).

To avoid any issue while deploying the new code, I propose to bump
the version of revscoring again, to re-publish a new artifact to Pypi.

Bug: T302851