### PR TITLE
Release 2.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.11.4]
+
+* No-op release, the artifact uploaded for 2.11.3 may not be the correct
+  one, hence a new release to avoid issues. The wheel was compiled with
+  Python 3.9 that should work just fine, but since the project support
+  only Python 3.7 we want to be extra careful. The new wheel has been
+  created from a Python 3.7 venv.
+
 ## [2.11.3]
 
 * No-op release, the artifact uploaded for 2.11.2 may not be the correct

--- a/revscoring/about.py
+++ b/revscoring/about.py
@@ -1,5 +1,5 @@
 __name__ = "revscoring"
-__version__ = "2.11.3"
+__version__ = "2.11.4"
 __author__ = "Aaron Halfaker"
 __author_email__ = "ahalfaker@wikimedia.org"
 __description__ = ("A set of utilities for generating quality scores for " +


### PR DESCRIPTION
The 2.11.3 release was created from a Python 3.9 venv, that should
work just fine but to be extra careful we created a new version
from a 3.7 venv.