### PR TITLE
Update numpy and nltk dependencies and release 2.11.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ mwbase >= 0.1.4, < 0.1.999
 mwtypes >= 0.2.0, < 0.3.999
 mwparserfromhell >= 0.6.1, < 0.6.999
 mysqltsv >= 0.0.7, < 0.0.999
-nltk == 3.5
-numpy >= 1.18.4, < 1.19.999
+nltk == 3.6.6
+numpy >= 1.21, < 1.21.999
 pytz >= 2017.2
 requests >= 2.0.0, < 2.999.999
 pyenchant >= 1.6.6, < 1.6.999

--- a/revscoring/about.py
+++ b/revscoring/about.py
@@ -1,5 +1,5 @@
 __name__ = "revscoring"
-__version__ = "2.11.6"
+__version__ = "2.11.7"
 __author__ = "Aaron Halfaker"
 __author_email__ = "ahalfaker@wikimedia.org"
 __description__ = ("A set of utilities for generating quality scores for " +


### PR DESCRIPTION
The GH's dependabot alerted us about some dependencies that need a bump to fix some low priority security concerns.

Release also version 2.11.7

Bug: T325366