### PR TITLE
[fix] version bump for GHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.11.8]
+* Add new github action that pushes to PYPI - no code relevant changes
+
 ## [2.11.6]
 
 * Allow mwapi up to 0.6.x in requirements.txt

--- a/revscoring/about.py
+++ b/revscoring/about.py
@@ -1,5 +1,5 @@
 __name__ = "revscoring"
-__version__ = "2.11.7"
+__version__ = "2.11.8"
 __author__ = "Aaron Halfaker"
 __author_email__ = "ahalfaker@wikimedia.org"
 __description__ = ("A set of utilities for generating quality scores for" +


### PR DESCRIPTION
This PR bumps the version in order to trigger the github action that pushes to PYPI